### PR TITLE
feat: woot background service testability

### DIFF
--- a/Server/Dtos/WootNamedFeedDto.cs
+++ b/Server/Dtos/WootNamedFeedDto.cs
@@ -2,6 +2,6 @@
 {
     public class WootNamedFeedDto
     {
-        public ICollection<WootFeedItemDto> Items { get; set; } = null!;
+        public List<WootFeedItemDto> Items { get; set; } = null!;
     }
 }

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -45,6 +45,7 @@ builder.Services.AddAuthentication(options =>
 // https://learn.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
 builder.Services.AddHttpClient<WootService>();
 builder.Services.AddScoped<WootService>();
+builder.Services.AddScoped<WootClient>();
 builder.Services.AddHostedService<WootWorkerService>();
 
 // Logging WootWorkerService.

--- a/Server/Services/WootClient.cs
+++ b/Server/Services/WootClient.cs
@@ -1,0 +1,92 @@
+﻿using Server.Dtos;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace Server.Services;
+
+/// <summary>
+/// Encapsulates HTTP requests to/responses from the Woot! Developer API,
+/// documented at https://developer.woot.com/#woot-web-developer-api.
+/// </summary>
+/// <remarks>
+/// Hence the "Client" naming scheme, aligned with HttpClient.
+/// </remarks>
+public class WootClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<WootClient> _logger;
+
+    public WootClient(
+        IConfiguration config,
+        HttpClient httpClient,
+        ILogger<WootClient> logger)
+    {
+        _httpClient = httpClient;
+        _httpClient.BaseAddress = new Uri("https://developer.woot.com/");
+        _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        // Secret Manager tool (development), see:
+        // https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=windows
+        _httpClient.DefaultRequestHeaders.Add("x-api-key", config["Woot:DeveloperApiKey"]);
+        _logger = logger;
+    }
+    /// <summary>
+    /// Retrieve live minified Woot! offers under the "Computers" feed from the
+    /// Woot! API GetNamedFeed endpoint at https://developer.woot.com/#getnamedfeed.
+    /// </summary>
+    /// <returns>
+    /// The live minified Woot! offers under the "Computers" feed.
+    /// </returns>
+    public async Task<List<WootFeedItemDto>> GetComputerFeed()
+    {
+        // Call the GetNamedFeed endpoint in the Woot! Developer API.
+        using HttpResponseMessage response = await _httpClient.GetAsync("feed/Computers");
+        Stream responseBody = response.Content.ReadAsStream();
+
+        try
+        {
+            WootNamedFeedDto? feed = JsonSerializer.Deserialize<WootNamedFeedDto>(responseBody);
+            return (feed is null) ? [] : feed.Items;
+        }
+        catch (JsonException)
+        {
+            _logger.LogInformation(response.Content.ToString());
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Retrieve whole Woot! offers from the Woot! API GetOffers endpoint,
+    /// documented at https://developer.woot.com/#getoffers
+    /// </summary>
+    /// <param name="ids">The IDs of the offers to retrieve.</param>
+    /// <returns>The corresponding Woot! offers with all their properties.</returns>
+    public async Task<List<WootOfferDto>> GetWootOffers(List<Guid> ids)
+    {
+        List<WootOfferDto> offers = [];
+
+        // Iterate through in increments of 25 ids per loop,
+        // because the Woot! API's GetOffers endpoint enforces a 25-offer maximum.
+        for (int i = 0; i < ids.Count; i += 25)
+        {
+            IEnumerable<Guid> idBatch = ids.Skip(i).Take(25);
+            // Assemble the body parameter for the request to the GetOffers endpoint.
+            HttpContent content = new StringContent(JsonSerializer.Serialize(idBatch));
+
+            // Call the GetOffers endpoint in the Woot! Developer API.
+            using HttpResponseMessage response = await _httpClient.PostAsync("getoffers", content);
+            Stream responseBody = response.Content.ReadAsStream();
+
+            try
+            {
+                var offerBatch = JsonSerializer.Deserialize<List<WootOfferDto>>(responseBody) ?? [];
+                offers.AddRange(offerBatch);
+            }
+            catch (JsonException)
+            {
+                _logger.LogInformation(response.Content.ToString());
+            }
+        }
+
+        return offers;
+    }
+}

--- a/Server/Services/WootClient.cs
+++ b/Server/Services/WootClient.cs
@@ -21,6 +21,9 @@ public class WootClient
         HttpClient httpClient,
         ILogger<WootClient> logger)
     {
+        // HttpClient configuration in constructor of Typed Client
+        // rather than during registration in Program.cs, per:
+        // https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-8.0
         _httpClient = httpClient;
         _httpClient.BaseAddress = new Uri("https://developer.woot.com/");
         _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
@@ -36,7 +39,7 @@ public class WootClient
     /// <returns>
     /// The live minified Woot! offers under the "Computers" feed.
     /// </returns>
-    public async Task<List<WootFeedItemDto>> GetComputerFeed()
+    public async Task<List<WootFeedItemDto>> GetComputerFeedAsync()
     {
         // Call the GetNamedFeed endpoint in the Woot! Developer API.
         using HttpResponseMessage response = await _httpClient.GetAsync("feed/Computers");
@@ -60,7 +63,7 @@ public class WootClient
     /// </summary>
     /// <param name="ids">The IDs of the offers to retrieve.</param>
     /// <returns>The corresponding Woot! offers with all their properties.</returns>
-    public async Task<List<WootOfferDto>> GetWootOffers(List<Guid> ids)
+    public async Task<List<WootOfferDto>> GetWootOffersAsync(List<Guid> ids)
     {
         List<WootOfferDto> offers = [];
 

--- a/Server/Services/WootService.cs
+++ b/Server/Services/WootService.cs
@@ -18,7 +18,6 @@ public class WootService
     private readonly List<WootFeedItemDto> _feedItems;
     private readonly ICollection<WootOfferDto> _wootOffers;
 
-
     // HttpClient configuration in constructor of Typed Client
     // rather than during registration in Program.cs, per:
     // https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-8.0
@@ -79,7 +78,6 @@ public class WootService
     /// Retrieve the requested offers with all their properties from the Woot! API
     /// GetOffers endpoint, documented at https://developer.woot.com/#getoffers
     /// </summary>
-    /// <param name="items">The Woot! API Feed Items (minified offers).</param>
     /// <returns>The corresponding Woot! offers with all their properties.</returns>
     public async Task<WootService> GetAllPropertiesForFeedItems()
     {

--- a/Server/Services/WootService.cs
+++ b/Server/Services/WootService.cs
@@ -123,7 +123,7 @@ public class WootService
             {
                 _logger.LogInformation(response.Content.ToString());
             }
-    }
+        }
 
         // Re-assign category.
         foreach (var offer in offers)

--- a/Server/Services/WootService.cs
+++ b/Server/Services/WootService.cs
@@ -145,7 +145,10 @@ public class WootService
     /// offers in the schema documented at https://developer.woot.com/#tocs_offer,
     /// then persist them to the database.
     /// </summary>
-    public async Task<WootService> SaveOffersAsync()
+    /// <returns>
+    /// No result (as a terminal operation that persists to the database).
+    /// </returns>
+    public async Task SaveOffersAsync()
     {
         ICollection<Offer> offers = new List<Offer>();
 
@@ -183,8 +186,6 @@ public class WootService
         }
 
         await _context.SaveChangesAsync();
-
-        return this;
     }
 
     /// <summary>
@@ -192,11 +193,14 @@ public class WootService
     /// (A.) not included in the response of live minified offers from Woot! or
     /// (B.) included, but are marked as sold out.
     /// </summary>
+    /// <returns>
+    /// No result (as a terminal operation that persists to the database).
+    /// </returns>
     /// <remarks>
     /// Minified offers from the Woot! API's GetNamedFeed endpoint, while live,
     /// are not necessarily still in stock.
     /// </remarks>
-    public async Task<WootService> UpdateSoldOutOffersAsync()
+    public async Task UpdateSoldOutOffersAsync()
     {
         HashSet<Guid> inStockOfferIdSet = new(_feedItems // HashSet for lookup time
             .Where(o => !o.IsSoldOut) // Not all sold out offers are returned.
@@ -214,8 +218,6 @@ public class WootService
         }
 
         await _context.SaveChangesAsync();
-
-        return this;
     }
 
     private List<HardwareConfiguration> GetHardwareConfigurations(WootOfferDto offer)

--- a/Server/Services/WootService.cs
+++ b/Server/Services/WootService.cs
@@ -131,8 +131,8 @@ public class WootService
         // Re-assign category.
         foreach (var offer in offers)
         {
-            categoriesById.TryGetValue(offer.WootId, out string category);
-            offer.Category = category;
+            categoriesById.TryGetValue(offer.WootId, out string? category);
+            offer.Category = (category is null) ? string.Empty : category;
         }
 
         _wootOffers.AddRange(offers);

--- a/Server/WootServiceExtensions.cs
+++ b/Server/WootServiceExtensions.cs
@@ -4,6 +4,15 @@ namespace Server;
 
 public static class WootServiceExtensions
 {
+    /// <summary>
+    /// Overloads and awaits an async method of WootService to allow its chaining.
+    /// </summary>
+    /// <remarks>
+    /// For reference, see the forum posts:
+    /// https://stackoverflow.com/a/52739551 & https://stackoverflow.com/a/32112709.
+    /// </remarks>
+    /// <param name="task">The extended Fluent API type.</param>
+    /// <returns>The Fluent API object.</returns>
     public static async Task<WootService> GetAllPropertiesForFeedItems(this Task<WootService> task)
     {
         var service = await task;

--- a/Server/WootServiceExtensions.cs
+++ b/Server/WootServiceExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Server.Services;
+
+namespace Server;
+
+public static class WootServiceExtensions
+{
+    public static async Task<WootService> GetAllPropertiesForFeedItems(this Task<WootService> task)
+    {
+        var service = await task;
+        return await service.GetAllPropertiesForFeedItems();
+    }
+}

--- a/Server/WootServiceExtensions.cs
+++ b/Server/WootServiceExtensions.cs
@@ -2,20 +2,55 @@
 
 namespace Server;
 
+/// <remarks>
+/// For reference, see the forum posts:
+/// https://stackoverflow.com/a/52739551 & https://stackoverflow.com/a/32112709.
+/// </remarks>
 public static class WootServiceExtensions
 {
     /// <summary>
     /// Overloads and awaits an async method of WootService to allow its chaining.
+    /// Retrieves full Woot! offers from the Woot! API 
+    /// based on the set of stored WootFeedItemDto IDs.
     /// </summary>
-    /// <remarks>
-    /// For reference, see the forum posts:
-    /// https://stackoverflow.com/a/52739551 & https://stackoverflow.com/a/32112709.
-    /// </remarks>
     /// <param name="task">The extended Fluent API type.</param>
     /// <returns>The Fluent API object.</returns>
-    public static async Task<WootService> GetAllPropertiesForFeedItems(this Task<WootService> task)
+    public static async Task<WootService> BuildWootOffersFromFeedAsync(this Task<WootService> task)
     {
         var service = await task;
-        return await service.GetAllPropertiesForFeedItems();
+        return await service.BuildWootOffersFromFeedAsync();
+    }
+
+    /// <summary>
+    /// Overloads and awaits an async method of WootService to allow its chaining.
+    /// Builds a collection of Offer objects (and their configurations) from the
+    /// set of stored Woot! offers in the schema documented at
+    /// https://developer.woot.com/#tocs_offer.
+    /// Then, tracks them if not already, and persists them to the database.
+    /// </summary>
+    /// <param name="task">The extended Fluent API type.</param>
+    /// <returns>
+    /// No result (as a terminal operation that persists to the database).
+    /// </returns>
+    public static async Task AddNewOffersAsync(this Task<WootService> task)
+    {
+        var service = await task;
+        await service.AddNewOffersAsync();
+    }
+
+    /// <summary>
+    /// Overloads and awaits an async method of WootService to allow its chaining.
+    /// Updates property `IsSoldOut` to true for existing offers that are either
+    /// (A.) not included in the stored set of live WootFeedItemDtos from Woot! or
+    /// (B.) included, but are marked as sold out.
+    /// </summary>
+    /// <param name="task">The extended Fluent API type.</param>
+    /// <returns>
+    /// No result (as a terminal operation that persists to the database).
+    /// </returns>
+    public static async Task UpdateSoldOutStatusAsync(this Task<WootService> task)
+    {
+        var service = await task;
+        await service.UpdateSoldOutStatusAsync();
     }
 }

--- a/Server/WootWorkerService.cs
+++ b/Server/WootWorkerService.cs
@@ -1,21 +1,17 @@
-﻿using Model;
-using Server.Dtos;
-using Server.Services;
+﻿using Server.Services;
 
 namespace Server
 {
     public class WootWorkerService(
-        ILogger<WootWorkerService> logger,
-        IServiceScopeFactory scopeFactory) : BackgroundService
+        IServiceScopeFactory scopeFactory,
+        ILogger<WootWorkerService> logger
+    ) : BackgroundService
     {
-        private readonly ILogger<WootWorkerService> _logger = logger;
-        private readonly IServiceScopeFactory _scopeFactory = scopeFactory;
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             using (var scope = scopeFactory.CreateScope())
             {
-                var context = scope.ServiceProvider.GetRequiredService<WootComputersSourceContext>();
                 var service = scope.ServiceProvider.GetRequiredService<WootService>();
 
                 await service
@@ -28,9 +24,9 @@ namespace Server
 
             while (!stoppingToken.IsCancellationRequested)
             {
-                if (_logger.IsEnabled(LogLevel.Information))
+                if (logger.IsEnabled(LogLevel.Information))
                 {
-                    _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+                    logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
                 }
                 await Task.Delay(1800000, stoppingToken);
             }

--- a/Server/WootWorkerService.cs
+++ b/Server/WootWorkerService.cs
@@ -18,10 +18,10 @@ namespace Server
                 var context = scope.ServiceProvider.GetRequiredService<WootComputersSourceContext>();
                 var service = scope.ServiceProvider.GetRequiredService<WootService>();
 
-                IEnumerable<WootFeedItemDto> feed = await service.GetComputers();
-                ICollection<WootOfferDto> wootOffers = await service.GetAllPropertiesForFeedItems(feed);
-                await service.SaveOffersAsync(wootOffers);
-                await service.UpdateSoldOutOffersAsync(feed);
+                await service.GetComputers();
+                await service.GetAllPropertiesForFeedItems();
+                await service.SaveOffersAsync();
+                await service.UpdateSoldOutOffersAsync();
             }
 
             while (!stoppingToken.IsCancellationRequested)

--- a/Server/WootWorkerService.cs
+++ b/Server/WootWorkerService.cs
@@ -15,12 +15,12 @@ namespace Server
 
                 // Setup and Intermediate operations.
                 await service
-                    .GetComputers() // .Load()
-                    .GetAllPropertiesForFeedItems(); // optional .Transform()
+                    .WithWootComputersFeedAsync() // .Load()
+                    .BuildWootOffersFromFeedAsync(); // optional .Transform()
 
                 // Terminal operations.
-                await service.SaveOffersAsync(); // requires .Load() and .Transform()
-                await service.UpdateSoldOutOffersAsync(); // requires .Load() only
+                await service.AddNewOffersAsync(); // requires .Load() and .Transform()
+                await service.UpdateSoldOutStatusAsync(); // requires .Load() only
             }
 
             while (!stoppingToken.IsCancellationRequested)

--- a/Server/WootWorkerService.cs
+++ b/Server/WootWorkerService.cs
@@ -18,10 +18,12 @@ namespace Server
                 var context = scope.ServiceProvider.GetRequiredService<WootComputersSourceContext>();
                 var service = scope.ServiceProvider.GetRequiredService<WootService>();
 
-                await service.GetComputers();
-                await service.GetAllPropertiesForFeedItems();
-                await service.SaveOffersAsync();
-                await service.UpdateSoldOutOffersAsync();
+                await service
+                    .GetComputers() // .Load()
+                    .GetAllPropertiesForFeedItems(); // optional .Transform()
+
+                await service.SaveOffersAsync(); // requires .Load() and .Transform()
+                await service.UpdateSoldOutOffersAsync(); // requires .Load() only
             }
 
             while (!stoppingToken.IsCancellationRequested)

--- a/Server/WootWorkerService.cs
+++ b/Server/WootWorkerService.cs
@@ -7,17 +7,18 @@ namespace Server
         ILogger<WootWorkerService> logger
     ) : BackgroundService
     {
-
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             using (var scope = scopeFactory.CreateScope())
             {
                 var service = scope.ServiceProvider.GetRequiredService<WootService>();
 
+                // Setup and Intermediate operations.
                 await service
                     .GetComputers() // .Load()
                     .GetAllPropertiesForFeedItems(); // optional .Transform()
 
+                // Terminal operations.
                 await service.SaveOffersAsync(); // requires .Load() and .Transform()
                 await service.UpdateSoldOutOffersAsync(); // requires .Load() only
             }


### PR DESCRIPTION
To facilitate unit tests for the program's integration with the Woot! Developer API:

- Refactor `WootService` into a Fluent API to better distinguish between configuration methods such as `WithWootComputersFeedAsync()` and terminating/effect methods such as `UpdateSoldOutStatusAsync()`. Write the `WootServiceExtensions` class to wrap the async `await`.
  - Only invoked by `WootWorkerService`, and not downstream of any HTTP requests, `WootService` can maintain state.
- Extract logic for `HttpClient` requests to the Woot! API out into `WootClient`, allowing both mock responses and tests on the construction of the requests themselves.