### PR TITLE
feat: add offers-controller unit tests

### DIFF
--- a/Server.Tests/DatabaseFixture.cs
+++ b/Server.Tests/DatabaseFixture.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Model;
+
+namespace Server.Tests;
+
+/// <remarks>
+/// Adapted from xUnit documentation at
+/// https://xunit.net/docs/shared-context#class-fixture.
+/// </remarks>
+public class DatabaseFixture : IDisposable
+{
+    public WootComputersSourceContext Context { get; set; }
+
+    public DatabaseFixture()
+    {
+        var options = new DbContextOptionsBuilder<WootComputersSourceContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        var context = new WootComputersSourceContext(options);
+
+        context.Add(new Offer()
+        {
+            WootId = Guid.NewGuid(),
+            Category = "Desktops",
+            Title = "Dell Optiplex 7070",
+            Photo = "https://d3gqasl9vmjfd8.cloudfront.net/8697eca7-d3bc-451b-9111-9086936d8ecf.png",
+            IsSoldOut = false,
+            Condition = "Refurbished",
+            Url = "https://computers.woot.com/offers/dell-optiplex-7070-micro-desktop-mini-pc-5",
+            Configurations = new[] { new HardwareConfiguration()
+                    { MemoryCapacity = 16, StorageSize = 256 }
+                }
+        });
+
+        context.Add(new Offer()
+        {
+            WootId = Guid.NewGuid(),
+            Category = "Laptops",
+            Title = "Dell Latitude 7420",
+            Photo = "https://d3gqasl9vmjfd8.cloudfront.net/7819b57e-e82e-4656-a7e7-916f9606c0c7.jpg",
+            IsSoldOut = false,
+            Condition = "Refurbished",
+            Url = "https://computers.woot.com/offers/dell-latitude-7420-business-14-laptop-6",
+            Configurations = new[] { new HardwareConfiguration()
+                    { MemoryCapacity = 32, StorageSize = 256}
+                }
+        });
+
+        context.SaveChanges();
+
+        Context = context;
+    }
+
+    public void Dispose()
+    {
+        Context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Server.Tests/DatabaseFixture.cs
+++ b/Server.Tests/DatabaseFixture.cs
@@ -18,13 +18,30 @@ public class DatabaseFixture : IDisposable
             .Options;
         var context = new WootComputersSourceContext(options);
 
+        // In-stock, multi-configuration Desktop.
+        context.Add(new Offer()
+        {
+            WootId = Guid.NewGuid(),
+            Category = "Desktops",
+            Title = "Dell Optiplex 7080",
+            Photo = "https://d3gqasl9vmjfd8.cloudfront.net/87ecd638-d90c-4006-ba40-87d01d6dd963.jpg",
+            IsSoldOut = false,
+            Condition = "Refurbished",
+            Url = "https://computers.woot.com/offers/dell-optiplex-7080-micro-4?ref=w_cnt_lnd_cat_pc_5_72",
+            Configurations = new[] {
+                new HardwareConfiguration() { MemoryCapacity = 16, StorageSize = 256 },
+                new HardwareConfiguration() { MemoryCapacity = 16, StorageSize = 512 },
+                new HardwareConfiguration() { MemoryCapacity = 32, StorageSize = 1000 }
+            }
+        });
+
         context.Add(new Offer()
         {
             WootId = Guid.NewGuid(),
             Category = "Desktops",
             Title = "Dell Optiplex 7070",
             Photo = "https://d3gqasl9vmjfd8.cloudfront.net/8697eca7-d3bc-451b-9111-9086936d8ecf.png",
-            IsSoldOut = false,
+            IsSoldOut = true,
             Condition = "Refurbished",
             Url = "https://computers.woot.com/offers/dell-optiplex-7070-micro-desktop-mini-pc-5",
             Configurations = new[] { new HardwareConfiguration()

--- a/Server.Tests/DatabaseFixture.cs
+++ b/Server.Tests/DatabaseFixture.cs
@@ -18,7 +18,7 @@ public class DatabaseFixture : IDisposable
             .Options;
         var context = new WootComputersSourceContext(options);
 
-        // In-stock, multi-configuration Desktop.
+        // In-stock, multi-configuration desktop.
         context.Add(new Offer()
         {
             WootId = Guid.NewGuid(),
@@ -35,6 +35,7 @@ public class DatabaseFixture : IDisposable
             }
         });
 
+        // Sold-out, single-configuration desktop.
         context.Add(new Offer()
         {
             WootId = Guid.NewGuid(),
@@ -49,6 +50,7 @@ public class DatabaseFixture : IDisposable
                 }
         });
 
+        // In-stock, single-configuration laptop.
         context.Add(new Offer()
         {
             WootId = Guid.NewGuid(),

--- a/Server.Tests/OrdersController_Test.cs
+++ b/Server.Tests/OrdersController_Test.cs
@@ -115,7 +115,7 @@ namespace Server.Tests
             var controller = new OffersController(_fixture.Context);
 
             // Act
-            var result = (await controller.GetOffers(null, [], [32])).Value;
+            var result = (await controller.GetOffers(null, [], [256])).Value;
 
             // Assert
             Assert.Equal(2, result.Count);

--- a/Server.Tests/OrdersController_Test.cs
+++ b/Server.Tests/OrdersController_Test.cs
@@ -1,10 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Options;
 using Model;
 using Server.Controllers;
 using Server.Dtos;
-using System.Configuration;
-using static System.Net.WebRequestMethods;
 
 namespace Server.Tests
 {
@@ -14,20 +11,13 @@ namespace Server.Tests
         /// Test the GetOffer() method.
         /// </summary>
         [Fact]
-        public async Task GetOffer()
+        public async Task GetOfferAsync()
         {
             // Arrange  
             var options = new DbContextOptionsBuilder<WootComputersSourceContext>()
                 .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
                 .Options;
             using var context = new WootComputersSourceContext(options);
-
-            var configuration = new HardwareConfiguration()
-            {
-                Id = 1,
-                MemoryCapacity = 16,
-                StorageSize = 256
-            };
 
             context.Add(new Offer()
             {
@@ -38,7 +28,9 @@ namespace Server.Tests
                 IsSoldOut = false,
                 Condition = "Refurbished",
                 Url = "https://computers.woot.com/offers/dell-optiplex-7070-micro-desktop-mini-pc-5",
-                Configurations = new[] { configuration }
+                Configurations = new[] { new HardwareConfiguration()
+                    { MemoryCapacity = 16, StorageSize = 256}
+                }
             });
             context.SaveChanges();
 

--- a/Server.Tests/OrdersController_Test.cs
+++ b/Server.Tests/OrdersController_Test.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Model;
 using Server.Controllers;
 using Server.Dtos;
@@ -102,6 +103,27 @@ namespace Server.Tests
             // Assert
             Assert.Equal(2, result.Count);
             Assert.All(result, o => Assert.Equal(256, o.StorageSize));
+        }
+
+        /// <summary>
+        /// Tests method GetOffers() with a single filter value applied for "memory"
+        /// and several filter values for "storage".
+        /// </summary>
+        [Fact]
+        public async Task GetOffersWith16GbMemoryAndAnyAmongStorageSelection()
+        {
+            // Arrange
+            var controller = new OffersController(_fixture.Context);
+            var storage = new List<short>() { 256, 512 };
+
+            // Act
+            var result = (await controller.GetOffers(null, [16], storage)).Value;
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.All(result, o => Assert.Equal("Desktops", o.Category));
+            Assert.All(result, o => Assert.Equal(16, o.MemoryCapacity));
+            Assert.All(result, o => Assert.Contains(o.StorageSize, storage));
         }
 
         /// <summary>

--- a/Server.Tests/OrdersController_Test.cs
+++ b/Server.Tests/OrdersController_Test.cs
@@ -121,5 +121,23 @@ namespace Server.Tests
             Assert.Equal(2, result.Count);
             Assert.All(result, o => Assert.Equal(256, o.StorageSize));
         }
+
+        /// <summary>
+        /// Tests method GetOffers() with all filters active.
+        /// </summary>
+        [Fact]
+        public async Task GetDesktopsWith16GbMemoryAnd256GbStorage()
+        {
+            // Arrange
+            var controller = new OffersController(_fixture.Context);
+
+            // Act
+            var result = (await controller.GetOffers("Desktops", [16], [256])).Value;
+
+            // Assert
+            Assert.All(result, o => Assert.Equal("Desktops", o.Category));
+            Assert.All(result, o => Assert.Equal(16, o.MemoryCapacity));
+            Assert.All(result, o => Assert.Equal(256, o.StorageSize));
+        }
     }
 }

--- a/Server.Tests/OrdersController_Test.cs
+++ b/Server.Tests/OrdersController_Test.cs
@@ -93,5 +93,33 @@ namespace Server.Tests
             Assert.Equal(1, result.Count);
             Assert.All(result, o => Assert.Equal("Desktops", o.Category));
         }
+
+        [Fact]
+        public async Task GetOffersByMemoryCapacityAsync()
+        {
+            // Arrange
+            var controller = new OffersController(_fixture.Context);
+
+            // Act
+            var result = (await controller.GetOffers(null, [16], [])).Value;
+
+            // Assert
+            Assert.Equal(1, result.Count);
+            Assert.All(result, o => Assert.Equal(16, o.MemoryCapacity));
+        }
+
+        [Fact]
+        public async Task GetOffersByStorageStorageAsync()
+        {
+            // Arrange
+            var controller = new OffersController(_fixture.Context);
+
+            // Act
+            var result = (await controller.GetOffers(null, [], [32])).Value;
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.All(result, o => Assert.Equal(256, o.StorageSize));
+        }
     }
 }

--- a/Server.Tests/OrdersController_Test.cs
+++ b/Server.Tests/OrdersController_Test.cs
@@ -56,6 +56,57 @@ namespace Server.Tests
         }
 
         [Fact]
+        public async Task GetAllOffersAsync()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<WootComputersSourceContext>()
+                .EnableSensitiveDataLogging()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+            using var context = new WootComputersSourceContext(options);
+
+            var expectedOffers = new List<Offer> {
+                new Offer()
+                {
+                    WootId = Guid.NewGuid(),
+                    Category = "Desktops",
+                    Title = "Dell Optiplex 7070",
+                    Photo = "https://d3gqasl9vmjfd8.cloudfront.net/8697eca7-d3bc-451b-9111-9086936d8ecf.png",
+                    IsSoldOut = false,
+                    Condition = "Refurbished",
+                    Url = "https://computers.woot.com/offers/dell-optiplex-7070-micro-desktop-mini-pc-5",
+                    Configurations = new[] { new HardwareConfiguration()
+                        { MemoryCapacity = 16, StorageSize = 256 }
+                    }
+                },
+                new Offer()
+                {
+                    WootId = Guid.NewGuid(),
+                    Category = "Laptops",
+                    Title = "Dell Latitude 7420",
+                    Photo = "https://d3gqasl9vmjfd8.cloudfront.net/7819b57e-e82e-4656-a7e7-916f9606c0c7.jpg",
+                    IsSoldOut = false,
+                    Condition = "Refurbished",
+                    Url = "https://computers.woot.com/offers/dell-latitude-7420-business-14-laptop-6",
+                    Configurations = new[] { new HardwareConfiguration()
+                        { MemoryCapacity = 32, StorageSize = 512}
+                    }
+                }
+            };
+
+            context.AddRange(expectedOffers);
+            context.SaveChanges();
+
+            var controller = new OffersController(context);
+
+            // Act
+            var result = (await controller.GetOffers(null, [], [])).Value;
+
+            // Assert
+            Assert.Equal(expectedOffers.Count, result.Count);
+        }
+
+        [Fact]
         public async Task GetOffersByCategoryAsync()
         {
             // Arrange

--- a/Server.Tests/OrdersController_Test.cs
+++ b/Server.Tests/OrdersController_Test.cs
@@ -5,42 +5,27 @@ using Server.Dtos;
 
 namespace Server.Tests
 {
-    public class OrdersController_Test
+    public class OrdersController_Test : IClassFixture<DatabaseFixture>
     {
+        private readonly DatabaseFixture _fixture;
+
+        public OrdersController_Test(DatabaseFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
         /// <summary>
         /// Test the GetOffer() method.
         /// </summary>
         [Fact]
         public async Task GetOfferAsync()
         {
-            // Arrange  
-            var options = new DbContextOptionsBuilder<WootComputersSourceContext>()
-                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-                .Options;
-            using var context = new WootComputersSourceContext(options);
-
-            context.Add(new Offer()
-            {
-                Id = 1,
-                Category = "Desktops",
-                Title = "Dell Optiplex 7070",
-                Photo = "https://d3gqasl9vmjfd8.cloudfront.net/8697eca7-d3bc-451b-9111-9086936d8ecf.png",
-                IsSoldOut = false,
-                Condition = "Refurbished",
-                Url = "https://computers.woot.com/offers/dell-optiplex-7070-micro-desktop-mini-pc-5",
-                Configurations = new[] { new HardwareConfiguration()
-                    { MemoryCapacity = 16, StorageSize = 256}
-                }
-            });
-            context.SaveChanges();
-
-            var controller = new OffersController(context);
-            OfferItemDto? offer_existing = null;
-            OfferItemDto? offer_notExisting = null;
+            // Arrange
+            var controller = new OffersController(_fixture.Context);
 
             // Act
-            offer_existing = (await controller.GetOffer(1)).Value;
-            offer_notExisting = (await controller.GetOffer(2)).Value;
+            OfferItemDto? offer_existing = (await controller.GetOffer(1)).Value;
+            OfferItemDto? offer_notExisting = (await controller.GetOffer(32767)).Value;
 
             // Assert
             Assert.NotNull(offer_existing);
@@ -86,10 +71,7 @@ namespace Server.Tests
                 }
             };
 
-            context.AddRange(expectedOffers);
-            context.SaveChanges();
-
-            var controller = new OffersController(context);
+            var controller = new OffersController(_fixture.Context);
 
             // Act
             var result = (await controller.GetOffers(null, [], [])).Value;
@@ -102,43 +84,7 @@ namespace Server.Tests
         public async Task GetOffersByCategoryAsync()
         {
             // Arrange
-            var options = new DbContextOptionsBuilder<WootComputersSourceContext>()
-                .EnableSensitiveDataLogging()
-                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-                .Options;
-            using var context = new WootComputersSourceContext(options);
-
-            context.Add(new Offer()
-            {
-                WootId = Guid.NewGuid(),
-                Category = "Desktops",
-                Title = "Dell Optiplex 7070",
-                Photo = "https://d3gqasl9vmjfd8.cloudfront.net/8697eca7-d3bc-451b-9111-9086936d8ecf.png",
-                IsSoldOut = false,
-                Condition = "Refurbished",
-                Url = "https://computers.woot.com/offers/dell-optiplex-7070-micro-desktop-mini-pc-5",
-                Configurations = new[] { new HardwareConfiguration() 
-                    { MemoryCapacity = 16, StorageSize = 256 } 
-                }
-            });
-
-            context.Add(new Offer()
-            {
-                WootId = Guid.NewGuid(),
-                Category = "Laptops",
-                Title = "Dell Latitude 7420",
-                Photo = "https://d3gqasl9vmjfd8.cloudfront.net/7819b57e-e82e-4656-a7e7-916f9606c0c7.jpg",
-                IsSoldOut = false,
-                Condition = "Refurbished",
-                Url = "https://computers.woot.com/offers/dell-latitude-7420-business-14-laptop-6",
-                Configurations = new[] { new HardwareConfiguration()
-                    { MemoryCapacity = 32, StorageSize = 256}
-                }
-            });
-
-            context.SaveChanges();
-
-            var controller = new OffersController(context);
+            var controller = new OffersController(_fixture.Context);
 
             // Act
             var result = (await controller.GetOffers("Desktops", [], [])).Value;

--- a/Server.Tests/OrdersController_Test.cs
+++ b/Server.Tests/OrdersController_Test.cs
@@ -32,6 +32,9 @@ namespace Server.Tests
             Assert.Null(offer_notExisting);
         }
 
+        /// <summary>
+        /// Tests the GetOffers() method, which filters out offers flagged isSoldOut.
+        /// </summary>
         [Fact]
         public async Task GetAllOffersAsync()
         {
@@ -47,6 +50,10 @@ namespace Server.Tests
             Assert.Equal(expected, result.Count);
         }
 
+        /// <summary>
+        /// Tests the GetOffers() method, set to filter for category "Desktops."
+        /// Applies no filters for "memory" or "storage."
+        /// </summary>
         [Fact]
         public async Task GetOffersByCategoryAsync()
         {
@@ -61,6 +68,10 @@ namespace Server.Tests
             Assert.All(result, o => Assert.Equal("Desktops", o.Category));
         }
 
+        /// <summary>
+        /// Tests the GetOffers() method, set to filter for a single select memory capacity.
+        /// Applies no filters for "category" or "storage."
+        /// </summary>
         [Fact]
         public async Task GetOffersByMemoryCapacityAsync()
         {
@@ -75,6 +86,10 @@ namespace Server.Tests
             Assert.All(result, o => Assert.Equal(16, o.MemoryCapacity));
         }
 
+        /// <summary>
+        /// Tests the GetOffers() method, set to filter for a single select storage size.
+        /// Applies no filters for "category" or "memory."
+        /// </summary>
         [Fact]
         public async Task GetOffersByStorageStorageAsync()
         {
@@ -91,6 +106,7 @@ namespace Server.Tests
 
         /// <summary>
         /// Tests method GetOffers() with all filters active.
+        /// Filters "memory" and "storage" with single values.
         /// </summary>
         [Fact]
         public async Task GetDesktopsWith16GbMemoryAnd256GbStorage()

--- a/Server.Tests/OrdersController_Test.cs
+++ b/Server.Tests/OrdersController_Test.cs
@@ -36,40 +36,7 @@ namespace Server.Tests
         public async Task GetAllOffersAsync()
         {
             // Arrange
-            var options = new DbContextOptionsBuilder<WootComputersSourceContext>()
-                .EnableSensitiveDataLogging()
-                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-                .Options;
-            using var context = new WootComputersSourceContext(options);
-
-            var expectedOffers = new List<Offer> {
-                new Offer()
-                {
-                    WootId = Guid.NewGuid(),
-                    Category = "Desktops",
-                    Title = "Dell Optiplex 7070",
-                    Photo = "https://d3gqasl9vmjfd8.cloudfront.net/8697eca7-d3bc-451b-9111-9086936d8ecf.png",
-                    IsSoldOut = false,
-                    Condition = "Refurbished",
-                    Url = "https://computers.woot.com/offers/dell-optiplex-7070-micro-desktop-mini-pc-5",
-                    Configurations = new[] { new HardwareConfiguration()
-                        { MemoryCapacity = 16, StorageSize = 256 }
-                    }
-                },
-                new Offer()
-                {
-                    WootId = Guid.NewGuid(),
-                    Category = "Laptops",
-                    Title = "Dell Latitude 7420",
-                    Photo = "https://d3gqasl9vmjfd8.cloudfront.net/7819b57e-e82e-4656-a7e7-916f9606c0c7.jpg",
-                    IsSoldOut = false,
-                    Condition = "Refurbished",
-                    Url = "https://computers.woot.com/offers/dell-latitude-7420-business-14-laptop-6",
-                    Configurations = new[] { new HardwareConfiguration()
-                        { MemoryCapacity = 32, StorageSize = 512}
-                    }
-                }
-            };
+            int expected = 4;
 
             var controller = new OffersController(_fixture.Context);
 
@@ -77,7 +44,7 @@ namespace Server.Tests
             var result = (await controller.GetOffers(null, [], [])).Value;
 
             // Assert
-            Assert.Equal(expectedOffers.Count, result.Count);
+            Assert.Equal(expected, result.Count);
         }
 
         [Fact]
@@ -90,7 +57,7 @@ namespace Server.Tests
             var result = (await controller.GetOffers("Desktops", [], [])).Value;
 
             // Assert
-            Assert.Equal(1, result.Count);
+            Assert.Equal(3, result.Count);
             Assert.All(result, o => Assert.Equal("Desktops", o.Category));
         }
 
@@ -104,7 +71,7 @@ namespace Server.Tests
             var result = (await controller.GetOffers(null, [16], [])).Value;
 
             // Assert
-            Assert.Equal(1, result.Count);
+            Assert.Equal(2, result.Count);
             Assert.All(result, o => Assert.Equal(16, o.MemoryCapacity));
         }
 

--- a/Server/Controllers/OffersController.cs
+++ b/Server/Controllers/OffersController.cs
@@ -16,7 +16,7 @@ namespace Server.Controllers
 
         // GET: api/Offers
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<OfferItemDto>>> GetOffers(
+        public async Task<ActionResult<ICollection<OfferItemDto>>> GetOffers(
             [FromQuery] string? category,
             [FromQuery] List<short> memory,
             [FromQuery] List<short> storage)

--- a/Server/Controllers/OffersController.cs
+++ b/Server/Controllers/OffersController.cs
@@ -41,18 +41,22 @@ namespace Server.Controllers
             {
                 foreach (var config in offer.Configurations)
                 {
-                    items.Add(new OfferItemDto()
+                    if ((memory.IsNullOrEmpty() || memory.Contains(config.MemoryCapacity))
+                        && (storage.IsNullOrEmpty() || storage.Contains(config.StorageSize)))
                     {
-                        Id = config.Id,
-                        Category = offer.Category,
-                        Title = offer.Title,
-                        Photo = offer.Photo,
-                        MemoryCapacity = config.MemoryCapacity,
-                        StorageSize = config.StorageSize,
-                        Price = config.Price,
-                        IsSoldOut = offer.IsSoldOut,
-                        Url = offer.Url,
-                    });
+                        items.Add(new OfferItemDto()
+                        {
+                            Id = config.Id,
+                            Category = offer.Category,
+                            Title = offer.Title,
+                            Photo = offer.Photo,
+                            MemoryCapacity = config.MemoryCapacity,
+                            StorageSize = config.StorageSize,
+                            Price = config.Price,
+                            IsSoldOut = offer.IsSoldOut,
+                            Url = offer.Url,
+                        });
+                    }
                 }
             }
 


### PR DESCRIPTION
To unit test the filtering functionality of the `GetOffers()` method:

- Fix a small bug in the filtering logic that returned all configurations of an `Offer` if any one config passed all filters.
- Use an in-memory database fixture and pre-populate it with entities for reuse across test cases.
  - Represent offer categories, in-stock/sold-out offers, and offers with more than one `HardwareConfiguration`.
- Write test cases for:
  - No filters applied.
  - Single filter (category/memory capacity/storage size) applied.
  - Multiple values (256 GB or 512 GB) for a filter (storage size) applied.
  - All filters applied.