### PR TITLE
feat: add woot service tests

### DIFF
--- a/Server.Tests/WootService_Test.cs
+++ b/Server.Tests/WootService_Test.cs
@@ -1,0 +1,156 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Model;
+using NSubstitute;
+using Server.Dtos;
+using Server.Services;
+using Server.Services.Interfaces;
+using System;
+
+namespace Server.Tests;
+
+public class WootService_Test : IDisposable
+{
+    private readonly WootComputersSourceContext _context;
+    private readonly Guid _wootOfferId;
+
+    /// <summary>
+    /// Shares setup without sharing object instances.
+    /// </summary>
+    /// <remarks>
+    /// Adapted from https://xunit.net/docs/shared-context#constructor.
+    /// </remarks>
+    public WootService_Test()
+    {
+        var options = new DbContextOptionsBuilder<WootComputersSourceContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new WootComputersSourceContext(options);
+
+        _wootOfferId = Guid.NewGuid();
+
+        _context.Add(new Offer()
+        {
+            WootId = _wootOfferId,
+            Category = "Desktops",
+            Title = "Dell Optiplex 7080",
+            Photo = "https://d3gqasl9vmjfd8.cloudfront.net/87ecd638-d90c-4006-ba40-87d01d6dd963.jpg",
+            IsSoldOut = false,
+            Condition = "Refurbished",
+            Url = "https://computers.woot.com/offers/dell-optiplex-7080-micro-4?ref=w_cnt_lnd_cat_pc_5_72",
+            Configurations = new[] {
+                new HardwareConfiguration() { MemoryCapacity = 16, StorageSize = 256 },
+                new HardwareConfiguration() { MemoryCapacity = 16, StorageSize = 512 },
+                new HardwareConfiguration() { MemoryCapacity = 32, StorageSize = 1000 }
+            }
+        });
+
+        _context.Add(new Offer()
+        {
+            WootId = Guid.NewGuid(),
+            Category = "Laptops",
+            Title = "Dell Latitude 7420",
+            Photo = "https://d3gqasl9vmjfd8.cloudfront.net/7819b57e-e82e-4656-a7e7-916f9606c0c7.jpg",
+            IsSoldOut = false,
+            Condition = "Refurbished",
+            Url = "https://computers.woot.com/offers/dell-latitude-7420-business-14-laptop-6",
+            Configurations = new[] { new HardwareConfiguration()
+                    { MemoryCapacity = 32, StorageSize = 256}
+                }
+        });
+
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [Fact]
+    public async Task UpdateSoldOutStatusNullOrEmpty()
+    {
+        // Arrange
+        _context.SaveChanges();
+
+        var client = Substitute.For<IWootClient>();
+        // Mock an (erroneous) empty return.
+        client.GetComputerFeedAsync().Returns([]);
+
+        var service = new WootService(client, _context);
+
+        // Act
+        await service
+            .WithWootComputersFeedAsync() // Uses mocked GetComputerFeedAsync().
+            .UpdateSoldOutStatusAsync(); // Uses mocked DbContext.
+
+        // Assert
+        // A check is in place to guard against marking all offers sold-out,
+        // in the event of some problem with the call by WootClient.
+        Assert.Equal(2, _context.Offers.Where(o => o.IsSoldOut == false).Count());
+    }
+
+    /// <summary>
+    /// Tests the UpdateSoldOutStatus() method for the case in which no tracked
+    /// offer is included in the feed of live offers.
+    /// </summary>
+    [Fact]
+    public async Task UpdateSoldOutStatusToTrueForAllOffers()
+    {
+        // Arrange
+        var wootFeedItem = new WootFeedItemDto
+        {
+            OfferId = Guid.NewGuid(), // No match with entity already in database.
+            Categories = ["PC/Desktops"],
+            IsSoldOut = false,
+        };
+
+        var client = Substitute.For<IWootClient>();
+        // Returns with a non-zero count of WootFeedItemDtos.
+        client.GetComputerFeedAsync().Returns([wootFeedItem]);
+
+        var service = new WootService(client, _context);
+
+        // Act
+        await service
+            .WithWootComputersFeedAsync() // Uses mocked GetComputerFeedAsync().
+            .UpdateSoldOutStatusAsync(); // Uses mocked DbContext.
+
+        // Assert
+        // All tracked offers are marked "sold-out."
+        Assert.Equal(0, _context.Offers.Where(o => o.IsSoldOut == false).Count());
+    }
+
+    /// <summary>
+    /// Tests updating the sold-out status of two offers, because one is
+    /// included in the live feed but marked "sold-out," and the other is
+    /// not included in the live feed and so no longer "live."
+    /// </summary>
+    [Fact]
+    public async Task UpdateSoldOutStatusWhenIncludedButMarked()
+    {
+        // Arrange
+        var wootFeedItem = new WootFeedItemDto
+        {
+            OfferId = _wootOfferId, // Matches a tracked offer.
+            Categories = ["PC/Desktops"],
+            IsSoldOut = true, // Distinct from previous test cases.
+        };
+
+        var client = Substitute.For<IWootClient>();
+        client.GetComputerFeedAsync().Returns([wootFeedItem]);
+
+        var service = new WootService(client, _context);
+
+        // Act
+        await service
+            .WithWootComputersFeedAsync() // Uses mocked GetComputerFeedAsync().
+            .UpdateSoldOutStatusAsync(); // Uses mocked DbContext.
+
+        // Assert
+        // Previous in-stock offer now "sold-out" after database update,
+        // because it was included in the collection of live (but sold out) offers.
+        // The other is now "sold-out", being not included in the live feed at all.
+        Assert.Equal(0, _context.Offers.Where(o => o.IsSoldOut == false).Count());
+    }
+}

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.IdentityModel.Tokens;
 using Model;
 using Server;
 using Server.Services;
+using Server.Services.Interfaces;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -45,7 +46,7 @@ builder.Services.AddAuthentication(options =>
 // https://learn.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
 builder.Services.AddHttpClient<WootService>();
 builder.Services.AddScoped<WootService>();
-builder.Services.AddScoped<WootClient>();
+builder.Services.AddScoped<IWootClient, WootClient>();
 builder.Services.AddHostedService<WootWorkerService>();
 
 // Logging WootWorkerService.

--- a/Server/Services/Interfaces/IWootClient.cs
+++ b/Server/Services/Interfaces/IWootClient.cs
@@ -1,0 +1,23 @@
+﻿using Server.Dtos;
+
+namespace Server.Services.Interfaces;
+
+public interface IWootClient
+{
+    /// <summary>
+    /// Retrieve live minified Woot! offers under the "Computers" feed from the
+    /// Woot! API GetNamedFeed endpoint at https://developer.woot.com/#getnamedfeed.
+    /// </summary>
+    /// <returns>
+    /// The live minified Woot! offers under the "Computers" feed.
+    /// </returns>
+    public Task<List<WootFeedItemDto>> GetComputerFeedAsync();
+
+    /// <summary>
+    /// Retrieve whole Woot! offers from the Woot! API GetOffers endpoint,
+    /// documented at https://developer.woot.com/#getoffers.
+    /// </summary>
+    /// <param name="ids">The IDs of the offers to retrieve.</param>
+    /// <returns>The corresponding Woot! offers with all their properties.</returns>
+    public Task<List<WootOfferDto>> GetWootOffersAsync(List<Guid> ids);
+}

--- a/Server/Services/WootClient.cs
+++ b/Server/Services/WootClient.cs
@@ -1,4 +1,5 @@
 ﻿using Server.Dtos;
+using Server.Services.Interfaces;
 using System.Net.Http.Headers;
 using System.Text.Json;
 
@@ -11,7 +12,7 @@ namespace Server.Services;
 /// <remarks>
 /// Hence the "Client" naming scheme, aligned with HttpClient.
 /// </remarks>
-public class WootClient
+public class WootClient : IWootClient
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<WootClient> _logger;

--- a/Server/Services/WootService.cs
+++ b/Server/Services/WootService.cs
@@ -2,26 +2,23 @@
 using Model;
 using NuGet.Packaging;
 using Server.Dtos;
+using Server.Services.Interfaces;
 using System.Text.RegularExpressions;
 
 namespace Server.Services;
 
 public class WootService
 {
-    private readonly ILogger<WootService> _logger;
-    private readonly WootClient _wootClient;
+    private readonly IWootClient _wootClient;
     private readonly WootComputersSourceContext _context;
     // Acceptable to maintain state because not invoked via HTTP.
     private readonly List<WootFeedItemDto> _feedItems;
     private readonly ICollection<WootOfferDto> _wootOffers;
 
     public WootService(
-        ILogger<WootService> logger,
-        IConfiguration config,
-        WootClient wootClient,
+        IWootClient wootClient,
         WootComputersSourceContext context)
     {
-        _logger = logger;
         _wootClient = wootClient;
         _context = context;
         _feedItems = [];

--- a/Server/Services/WootService.cs
+++ b/Server/Services/WootService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
 using Model;
 using NuGet.Packaging;
 using Server.Dtos;
@@ -151,7 +152,7 @@ public class WootService
         HashSet<Guid> inStockOfferIdSet = new(_feedItems // HashSet for lookup time
             .Where(o => !o.IsSoldOut) // Not all sold out offers are returned.
             .Select(o => o.OfferId));
-        if (inStockOfferIdSet.Count != 0) // Guard against faulty/empty responses.
+        if (!_feedItems.IsNullOrEmpty()) // Guard against faulty/empty responses.
         {
             // Compare tracked offers against the IDs of offers still in stock.
             var endedOffers = _context.Offers


### PR DESCRIPTION
To unit test `WootService`:

- Mock the `WootClient` dependency to avoid calls to the Woot! API.
- Test the `UpdateSoldOutStatusAsync()` method for the following cases:
  - An (erroneous) empty list of offers from the Woot! API.
  - A list of live offers from the Woot! API that includes no offers currently tracked.
  - A list of live offers, but in which one is marked "sold-out."
- Test the `AddNewOffersAsync()` method for the following boundaries:
  - An (erroneous) empty list of offers from the Woot! API.
  - Live offers from the Woot! API that are all already tracked.
  - Offers that require the use of various `WootService` conditional regular expressions to extract specifications.