### PR TITLE
feat: add bookmarking functionality

### DIFF
--- a/Model/Bookmark.cs
+++ b/Model/Bookmark.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Model;
+
+[Table("Bookmark")] // Override EF Core plural naming convention.
+public class Bookmark
+{
+    [Key]
+    public int Id { get; set; }
+
+    [ForeignKey(nameof(WooterComputerUser))]
+    public int UserId { get; set; }
+
+    [ForeignKey(nameof(Offer))]
+    public int OfferId { get; set; }
+
+    public Offer Offer { get; set; } = null!;
+
+    public DateTime CreatedAt { get; set; }
+}

--- a/Model/Bookmark.cs
+++ b/Model/Bookmark.cs
@@ -9,8 +9,9 @@ public class Bookmark
     [Key]
     public int Id { get; set; }
 
+    // Identity user type is string.
     [ForeignKey(nameof(WooterComputerUser))]
-    public int UserId { get; set; }
+    public required string UserId { get; set; }
 
     [ForeignKey(nameof(HardwareConfiguration))]
     public int ConfigurationId { get; set; }

--- a/Model/Bookmark.cs
+++ b/Model/Bookmark.cs
@@ -12,10 +12,10 @@ public class Bookmark
     [ForeignKey(nameof(WooterComputerUser))]
     public int UserId { get; set; }
 
-    [ForeignKey(nameof(Offer))]
-    public int OfferId { get; set; }
+    [ForeignKey(nameof(HardwareConfiguration))]
+    public int ConfigurationId { get; set; }
 
-    public Offer Offer { get; set; } = null!;
+    public HardwareConfiguration HardwareConfiguration { get; set; } = null!;
 
     public DateTime CreatedAt { get; set; }
 }

--- a/Model/Migrations/20250424191208_AddBookmark.Designer.cs
+++ b/Model/Migrations/20250424191208_AddBookmark.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Model;
 
@@ -11,9 +12,11 @@ using Model;
 namespace Model.Migrations
 {
     [DbContext(typeof(WootComputersSourceContext))]
-    partial class WootComputersSourceContextModelSnapshot : ModelSnapshot
+    [Migration("20250424191208_AddBookmark")]
+    partial class AddBookmark
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Model/Migrations/20250424191208_AddBookmark.cs
+++ b/Model/Migrations/20250424191208_AddBookmark.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBookmark : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Bookmark",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<int>(type: "int", nullable: false),
+                    OfferId = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Bookmark", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Bookmark_Offer_OfferId",
+                        column: x => x.OfferId,
+                        principalTable: "Offer",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Bookmark_OfferId",
+                table: "Bookmark",
+                column: "OfferId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Bookmark");
+        }
+    }
+}

--- a/Model/Migrations/20250424193806_ReplaceBookmarkOfferWithConfiguration.Designer.cs
+++ b/Model/Migrations/20250424193806_ReplaceBookmarkOfferWithConfiguration.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Model;
 
@@ -11,9 +12,11 @@ using Model;
 namespace Model.Migrations
 {
     [DbContext(typeof(WootComputersSourceContext))]
-    partial class WootComputersSourceContextModelSnapshot : ModelSnapshot
+    [Migration("20250424193806_ReplaceBookmarkOfferWithConfiguration")]
+    partial class ReplaceBookmarkOfferWithConfiguration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Model/Migrations/20250424193806_ReplaceBookmarkOfferWithConfiguration.cs
+++ b/Model/Migrations/20250424193806_ReplaceBookmarkOfferWithConfiguration.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class ReplaceBookmarkOfferWithConfiguration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Bookmark_Offer_OfferId",
+                table: "Bookmark");
+
+            migrationBuilder.RenameColumn(
+                name: "OfferId",
+                table: "Bookmark",
+                newName: "ConfigurationId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Bookmark_OfferId",
+                table: "Bookmark",
+                newName: "IX_Bookmark_ConfigurationId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Bookmark_Configuration_ConfigurationId",
+                table: "Bookmark",
+                column: "ConfigurationId",
+                principalTable: "Configuration",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Bookmark_Configuration_ConfigurationId",
+                table: "Bookmark");
+
+            migrationBuilder.RenameColumn(
+                name: "ConfigurationId",
+                table: "Bookmark",
+                newName: "OfferId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Bookmark_ConfigurationId",
+                table: "Bookmark",
+                newName: "IX_Bookmark_OfferId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Bookmark_Offer_OfferId",
+                table: "Bookmark",
+                column: "OfferId",
+                principalTable: "Offer",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Model/Migrations/20250424204955_UpdateBookmarkUserIdToDataTypeString.Designer.cs
+++ b/Model/Migrations/20250424204955_UpdateBookmarkUserIdToDataTypeString.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Model;
 
@@ -11,9 +12,11 @@ using Model;
 namespace Model.Migrations
 {
     [DbContext(typeof(WootComputersSourceContext))]
-    partial class WootComputersSourceContextModelSnapshot : ModelSnapshot
+    [Migration("20250424204955_UpdateBookmarkUserIdToDataTypeString")]
+    partial class UpdateBookmarkUserIdToDataTypeString
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Model/Migrations/20250424204955_UpdateBookmarkUserIdToDataTypeString.cs
+++ b/Model/Migrations/20250424204955_UpdateBookmarkUserIdToDataTypeString.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Model.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateBookmarkUserIdToDataTypeString : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "Bookmark",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "UserId",
+                table: "Bookmark",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+    }
+}

--- a/Model/WootComputersSourceContext.cs
+++ b/Model/WootComputersSourceContext.cs
@@ -21,6 +21,8 @@ public partial class WootComputersSourceContext : IdentityDbContext<WooterComput
 
     public virtual DbSet<Offer> Offers { get; set; }
 
+    public DbSet<Bookmark> Bookmarks { get; set; }
+
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         if (optionsBuilder.IsConfigured)

--- a/Server.Tests/BookmarksController_Test.cs
+++ b/Server.Tests/BookmarksController_Test.cs
@@ -1,0 +1,154 @@
+﻿using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Model;
+using Server.Controllers;
+using Server.Dtos;
+
+namespace Server.Tests;
+
+public class BookmarksController_Test : IDisposable
+{
+    private readonly WootComputersSourceContext _context;
+
+    /// <summary>
+    /// Shares setup without sharing object instances.
+    /// </summary>
+    /// <remarks>
+    /// Adapted from https://xunit.net/docs/shared-context#constructor.
+    /// </remarks>
+    public BookmarksController_Test()
+    {
+        var options = new DbContextOptionsBuilder<WootComputersSourceContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new WootComputersSourceContext(options);
+
+        _context.Users.Add(new WooterComputerUser()
+        {
+            Id = "12345678-1234-1234-1234-123456789abc",
+            UserName = "user",
+            Email = "user@email",
+            SecurityStamp = Guid.NewGuid().ToString(),
+        });
+
+        // User without any bookmarks.
+        _context.Users.Add(new WooterComputerUser()
+        {
+            Id = "12345678-1234-1234-1234-123456789xyz",
+            UserName = "none",
+            Email = "none@email",
+            SecurityStamp = Guid.NewGuid().ToString(),
+        });
+
+        _context.Add(new Offer()
+        {
+            Id = 1,
+            WootId = Guid.NewGuid(),
+            Category = "Desktops",
+            Title = "Dell Optiplex 7080",
+            Photo = "https://d3gqasl9vmjfd8.cloudfront.net/87ecd638-d90c-4006-ba40-87d01d6dd963.jpg",
+            IsSoldOut = false,
+            Condition = "Refurbished",
+            Url = "https://computers.woot.com/offers/dell-optiplex-7080-micro-4?ref=w_cnt_lnd_cat_pc_5_72",
+            Configurations = new[] {
+                new HardwareConfiguration() { Id = 1, MemoryCapacity = 16, StorageSize = 256 },
+                new HardwareConfiguration() { Id = 2, MemoryCapacity = 16, StorageSize = 512 },
+                new HardwareConfiguration() { Id = 3, MemoryCapacity = 32, StorageSize = 1000 }
+            }
+        });
+
+        _context.Add(new Bookmark()
+        {
+            UserId = "12345678-1234-1234-1234-123456789abc",
+            ConfigurationId = 1,
+            CreatedAt = DateTime.UtcNow,
+        });
+
+        _context.SaveChanges();
+    } 
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    [Theory]
+    // Valid user, with bookmarks.
+    [InlineData("12345678-1234-1234-1234-123456789abc", 1)]
+    // Valid user, without seeded bookmarks.
+    [InlineData("12345678-1234-1234-1234-123456789xyz", 0)]
+    public async Task GetBookmarksUsersExist(string userId, int expected)
+    {
+        // Arrange
+        var controller = new BookmarksController(_context);
+
+        // Act
+        IEnumerable<BookmarkDto> result = (await controller.GetBookmarks(userId)).Value;
+
+        // Assert
+        Assert.Equal(expected, result.Count());
+        Assert.All(result, b => Assert.Equal(userId, b.UserId));
+    }
+
+    [Fact]
+    public async Task GetBookmarksUserDoesNotExist()
+    {
+        // Arrange
+        var controller = new BookmarksController(_context);
+
+        // Act
+        var result = (await controller
+            .GetBookmarks("12345678-abcd-abcd-abcd-123456789qrs")).Value;
+
+        // Assert
+        Assert.Equal(0, result.Count());
+    }
+
+    [Theory]
+    // Valid user, with seeded bookmarks.
+    [InlineData("12345678-1234-1234-1234-123456789xyz", 1)]
+    public async Task PostBookmarkValidUser(string userId, int offerItemId)
+    {
+        // Arrange
+        var controller = new BookmarksController(_context);
+
+        // Act
+        await controller.PostBookmark(userId, offerItemId);
+
+        // Assert
+        Assert.Equal(2, _context.Bookmarks.Count());
+    }
+
+    [Fact]
+    public async Task DeleteBookmarkExists()
+    {
+        // Arrange
+        var controller = new BookmarksController(_context);
+
+        // Act
+        var result = (await controller.DeleteBookmark(1));
+
+        // Assert
+        var notFoundResult = Assert.IsType<NoContentResult>(result);
+        Assert.Equal(0, _context.Bookmarks.Count());
+        Assert.Equal(204, notFoundResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteBookmarkDoesNotExist()
+    {
+        // Arrange
+        var controller = new BookmarksController(_context);
+
+        // Act
+        var result = (await controller.DeleteBookmark(-1));
+
+        // Assert
+        var notFoundResult = Assert.IsType<NotFoundResult>(result);
+        // No change.
+        Assert.Equal(1, _context.Bookmarks.Count());
+        Assert.Equal(404, notFoundResult.StatusCode);
+    }
+}

--- a/Server/Controllers/BookmarksController.cs
+++ b/Server/Controllers/BookmarksController.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using Model;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Server.Dtos;
+using Server.Services;
+using System.Security.Claims;
 
 namespace Server.Controllers
 {
@@ -9,73 +10,146 @@ namespace Server.Controllers
     [ApiController]
     public class BookmarksController : ControllerBase
     {
-        private readonly WootComputersSourceContext _context;
+        private readonly BookmarkService _service;
 
-        public BookmarksController(WootComputersSourceContext context)
+        public BookmarksController(BookmarkService service)
         {
-            _context = context;
+            _service = service;
         }
 
-        // GET: api/Bookmarks
-        [HttpGet]
-        public async Task<ActionResult<IEnumerable<BookmarkDto>>> GetBookmarks(string userId)
+        /// <summary>
+        /// Gets all bookmarks that belong the authenticated user;
+        /// optionally, filter by the offer item (configuration) ID.
+        /// </summary>
+        /// <returns>The authenticated user's bookmarks.</returns>
+        [Authorize]
+        [HttpGet] // GET: api/Bookmarks
+        public async Task<ActionResult<IEnumerable<BookmarkDto>>> GetBookmarks(
+            [FromQuery] int? offerItemId)
         {
-            return await _context.Bookmarks
-                .Where(b => b.UserId == userId)
-                .Select(b => new BookmarkDto()
-                {
-                    Id = b.Id,
-                    UserId = b.UserId,
-                    ConfigurationId = b.ConfigurationId,
-                    Category = b.HardwareConfiguration.Offer.Category,
-                    Title = b.HardwareConfiguration.Offer.Title,
-                    Photo = b.HardwareConfiguration.Offer.Photo,
-                    MemoryCapacity = b.HardwareConfiguration.MemoryCapacity,
-                    StorageSize = b.HardwareConfiguration.StorageSize,
-                    Price = b.HardwareConfiguration.Price,
-                    IsSoldOut = b.HardwareConfiguration.Offer.IsSoldOut
-                })
-                .ToListAsync();
-        }
-
-        // POST: api/Bookmarks
-        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
-        [HttpPost]
-        public async Task<ActionResult> PostBookmark(string userId, int offerItemId)
-        {
-            var bookmark = new Bookmark()
+            string? id = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (id is null)
             {
-                UserId = userId,
-                ConfigurationId = offerItemId,
-                CreatedAt = DateTime.UtcNow
+                return NotFound();
+            }
+
+            var bookmarks = await _service.GetBookmarksByUserIdAsync(id, offerItemId);
+            var bookmarkDtos = bookmarks.Select(b => new BookmarkDto()
+            {
+                Id = b.Id,
+                UserId = b.UserId,
+                ConfigurationId = b.ConfigurationId,
+                Category = b.HardwareConfiguration.Offer.Category,
+                Title = b.HardwareConfiguration.Offer.Title,
+                Photo = b.HardwareConfiguration.Offer.Photo,
+                MemoryCapacity = b.HardwareConfiguration.MemoryCapacity,
+                StorageSize = b.HardwareConfiguration.StorageSize,
+                Price = b.HardwareConfiguration.Price,
+                IsSoldOut = b.HardwareConfiguration.Offer.IsSoldOut
+            }).ToList();
+            return Ok(bookmarkDtos);
+        }
+
+        /// <summary>
+        /// Gets a bookmark based on its identifier.
+        /// </summary>
+        /// <param name="id">The bookmark identifier.</param>
+        /// <returns>
+        /// A bookmark DTO that contains hardware specification and offer details.
+        /// </returns>
+        [Authorize]
+        [HttpGet("{id}")]
+        public async Task<ActionResult<BookmarkDto>> GetBookmark(int id)
+        {
+            var bookmark =  await _service.GetBookmark(id);
+
+            if (bookmark is null)
+            {
+                return NoContent();
+            }
+
+            var bookmarkDto = new BookmarkDto()
+            {
+                Id = bookmark.Id,
+                UserId = bookmark.UserId,
+                ConfigurationId = bookmark.ConfigurationId,
+                Category = bookmark.HardwareConfiguration.Offer.Category,
+                Title = bookmark.HardwareConfiguration.Offer.Title,
+                Photo = bookmark.HardwareConfiguration.Offer.Photo,
+                MemoryCapacity = bookmark.HardwareConfiguration.MemoryCapacity,
+                StorageSize = bookmark.HardwareConfiguration.StorageSize,
+                Price = bookmark.HardwareConfiguration.Price,
+                IsSoldOut = bookmark.HardwareConfiguration.Offer.IsSoldOut
             };
 
-            _context.Bookmarks.Add(bookmark);
-            await _context.SaveChangesAsync();
-
-            /* return CreatedAtAction("GetBookmark", new { id = bookmark.Id }, bookmark); */
-            return NoContent();
+            return Ok(bookmarkDto);
         }
 
-        // DELETE: api/Bookmarks/5
-        [HttpDelete("{id}")]
-        public async Task<IActionResult> DeleteBookmark(int id)
+        /// <summary>
+        /// Posts a bookmark that references the authenticated user and
+        /// the specified hardware configuration identifier of an offer.
+        /// </summary>
+        // To protect from overposting attacks,
+        // see https://go.microsoft.com/fwlink/?linkid=2123754
+        [Authorize]
+        [HttpPost] // POST: api/Bookmarks
+        public async Task<ActionResult<BookmarkDto>> PostBookmark(int offerItemId)
         {
-            var bookmark = await _context.Bookmarks.FindAsync(id);
+            string? id = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (id is null)
+            {
+                return NotFound();
+            }
+
+            var bookmark = await _service.CreateBookmarkAsync(id, offerItemId);
+
+            if (bookmark is null)
+            {
+                return Conflict("Offer already bookmarked for user.");
+            }
+
+            var bookmarkDto = new BookmarkDto()
+            {
+                Id = bookmark.Id,
+                UserId = bookmark.UserId,
+                ConfigurationId = bookmark.ConfigurationId,
+                Category = bookmark.HardwareConfiguration.Offer.Category,
+                Title = bookmark.HardwareConfiguration.Offer.Title,
+                Photo = bookmark.HardwareConfiguration.Offer.Photo,
+                MemoryCapacity = bookmark.HardwareConfiguration.MemoryCapacity,
+                StorageSize = bookmark.HardwareConfiguration.StorageSize,
+                Price = bookmark.HardwareConfiguration.Price,
+                IsSoldOut = bookmark.HardwareConfiguration.Offer.IsSoldOut
+            };
+
+            return CreatedAtAction("GetBookmark", new { id = bookmarkDto.Id }, bookmarkDto);
+        }
+
+        /// <summary>
+        /// Deletes the bookmark that corresponds to the currently authenticated user
+        /// and the specified offer item identifer, if it exists.
+        /// </summary>
+        /// <param name="offerItemId">The offer item (configuration) identifier.</param>
+        /// <returns>NoContent if successful.</returns>
+        [Authorize]
+        [HttpDelete] // DELETE: api/Bookmarks/5
+        public async Task<IActionResult> DeleteBookmark(int offerItemId)
+        {
+            string? id = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (id is null)
+            {
+                return NotFound();
+            }
+
+            var bookmark = await _service.GetBookmarksByUserIdAsync(id, offerItemId);
             if (bookmark == null)
             {
                 return NotFound();
             }
 
-            _context.Bookmarks.Remove(bookmark);
-            await _context.SaveChangesAsync();
+            await _service.DeleteBookmarkAsync(id, offerItemId);
 
             return NoContent();
-        }
-
-        private bool BookmarkExists(int id)
-        {
-            return _context.Bookmarks.Any(e => e.Id == id);
         }
     }
 }

--- a/Server/Controllers/BookmarksController.cs
+++ b/Server/Controllers/BookmarksController.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Model;
+using Server.Dtos;
+
+namespace Server.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class BookmarksController : ControllerBase
+    {
+        private readonly WootComputersSourceContext _context;
+
+        public BookmarksController(WootComputersSourceContext context)
+        {
+            _context = context;
+        }
+
+        // GET: api/Bookmarks
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<BookmarkDto>>> GetBookmarks(int userId)
+        {
+            return await _context.Bookmarks
+                .Where(b => b.UserId == userId)
+                .Select(b => new BookmarkDto()
+                {
+                    Id = b.Id,
+                    UserId = b.UserId,
+                    ConfigurationId = b.ConfigurationId,
+                    Title = b.HardwareConfiguration.Offer.Title,
+                    Photo = b.HardwareConfiguration.Offer.Photo,
+                    MemoryCapacity = b.HardwareConfiguration.MemoryCapacity,
+                    StorageSize = b.HardwareConfiguration.StorageSize,
+                    Price = b.HardwareConfiguration.Price,
+                    IsSoldOut = b.HardwareConfiguration.Offer.IsSoldOut
+                })
+                .ToListAsync();
+        }
+
+        // POST: api/Bookmarks
+        // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+        [HttpPost]
+        public async Task<ActionResult> PostBookmark(int userId, int offerItemId)
+        {
+            var bookmark = new Bookmark()
+            {
+                UserId = userId,
+                ConfigurationId = offerItemId,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            _context.Bookmarks.Add(bookmark);
+            await _context.SaveChangesAsync();
+
+            /* return CreatedAtAction("GetBookmark", new { id = bookmark.Id }, bookmark); */
+            return NoContent();
+        }
+
+        // DELETE: api/Bookmarks/5
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteBookmark(int id)
+        {
+            var bookmark = await _context.Bookmarks.FindAsync(id);
+            if (bookmark == null)
+            {
+                return NotFound();
+            }
+
+            _context.Bookmarks.Remove(bookmark);
+            await _context.SaveChangesAsync();
+
+            return NoContent();
+        }
+
+        private bool BookmarkExists(int id)
+        {
+            return _context.Bookmarks.Any(e => e.Id == id);
+        }
+    }
+}

--- a/Server/Controllers/BookmarksController.cs
+++ b/Server/Controllers/BookmarksController.cs
@@ -18,7 +18,7 @@ namespace Server.Controllers
 
         // GET: api/Bookmarks
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<BookmarkDto>>> GetBookmarks(int userId)
+        public async Task<ActionResult<IEnumerable<BookmarkDto>>> GetBookmarks(string userId)
         {
             return await _context.Bookmarks
                 .Where(b => b.UserId == userId)
@@ -40,7 +40,7 @@ namespace Server.Controllers
         // POST: api/Bookmarks
         // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
         [HttpPost]
-        public async Task<ActionResult> PostBookmark(int userId, int offerItemId)
+        public async Task<ActionResult> PostBookmark(string userId, int offerItemId)
         {
             var bookmark = new Bookmark()
             {

--- a/Server/Controllers/BookmarksController.cs
+++ b/Server/Controllers/BookmarksController.cs
@@ -27,6 +27,7 @@ namespace Server.Controllers
                     Id = b.Id,
                     UserId = b.UserId,
                     ConfigurationId = b.ConfigurationId,
+                    Category = b.HardwareConfiguration.Offer.Category,
                     Title = b.HardwareConfiguration.Offer.Title,
                     Photo = b.HardwareConfiguration.Offer.Photo,
                     MemoryCapacity = b.HardwareConfiguration.MemoryCapacity,

--- a/Server/Dtos/BookmarkDto.cs
+++ b/Server/Dtos/BookmarkDto.cs
@@ -1,0 +1,22 @@
+﻿namespace Server.Dtos;
+
+public class BookmarkDto
+{
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+
+    public int ConfigurationId { get; set; }
+
+    public string Title { get; set; } = null!;
+
+    public string Photo { get; set; } = null!;
+
+    public short MemoryCapacity { get; set; }
+
+    public short StorageSize { get; set; }
+
+    public decimal Price { get; set; }
+
+    public bool IsSoldOut { get; set; }
+}

--- a/Server/Dtos/BookmarkDto.cs
+++ b/Server/Dtos/BookmarkDto.cs
@@ -8,6 +8,8 @@ public class BookmarkDto
 
     public int ConfigurationId { get; set; }
 
+    public string Category { get; set; } = null!;
+
     public string Title { get; set; } = null!;
 
     public string Photo { get; set; } = null!;

--- a/Server/Dtos/BookmarkDto.cs
+++ b/Server/Dtos/BookmarkDto.cs
@@ -4,7 +4,7 @@ public class BookmarkDto
 {
     public int Id { get; set; }
 
-    public int UserId { get; set; }
+    public string UserId { get; set; } = null!;
 
     public int ConfigurationId { get; set; }
 

--- a/Server/JwtHandler.cs
+++ b/Server/JwtHandler.cs
@@ -28,7 +28,10 @@ public class JwtHandler(
 
     private async Task<List<Claim>> GetClaimsAsync(WooterComputerUser user)
     {
-        List<Claim> claims = [new Claim(ClaimTypes.Name, user.UserName!)];
+        List<Claim> claims = [
+            new Claim(ClaimTypes.Name, user.UserName!),
+            new Claim(ClaimTypes.NameIdentifier, user.Id)
+        ];
         claims.AddRange(from role in await userManager.GetRolesAsync(user) select new Claim(ClaimTypes.Role, role));
         return claims;
     }

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -75,6 +75,7 @@ builder.Services.AddHttpClient<WootService>();
 builder.Services.AddScoped<WootService>();
 builder.Services.AddScoped<IWootClient, WootClient>();
 builder.Services.AddHostedService<WootWorkerService>();
+builder.Services.AddScoped<BookmarkService>();
 
 // Logging WootWorkerService.
 builder.Services.AddLogging(builder => builder.AddConsole());

--- a/Server/Services/BookmarkService.cs
+++ b/Server/Services/BookmarkService.cs
@@ -1,0 +1,101 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using Model;
+
+namespace Server.Services;
+
+public class BookmarkService
+{
+    private readonly WootComputersSourceContext _context;
+
+    public BookmarkService(WootComputersSourceContext context)
+    {
+        _context = context;
+    }
+
+    /// <summary>
+    /// Gets all bookmarks from the database that belong the specified user ID;
+    /// optionally, filter by the offer item (configuration) ID.
+    /// </summary>
+    public async Task<List<Bookmark>> GetBookmarksByUserIdAsync(string userId, int? offerItemId)
+    {
+        var bookmarks =  await _context.Bookmarks
+            .Include(b => b.HardwareConfiguration)
+            .ThenInclude(c => c.Offer)
+            .Where(b => b.UserId == userId)
+            .ToListAsync();
+
+        if (offerItemId.HasValue)
+        {
+            bookmarks = bookmarks.Where(b => b.ConfigurationId == offerItemId).ToList();
+        }
+
+        return bookmarks;
+    }
+
+    /// <summary>
+    /// Get a bookmark from the database based on its unique identifier.
+    /// </summary>
+    public async Task<Bookmark?> GetBookmark(int id)
+    {
+        return await _context.Bookmarks
+            .Include(b => b.HardwareConfiguration)
+            .ThenInclude(c => c.Offer)
+            .FirstOrDefaultAsync(b => b.Id == id);
+    }
+
+    /// <summary>
+    /// Creates a bookmark that references the authenticated user's ID
+    /// and the specified hardware configuration identifier of an offer.
+    /// </summary>
+    public async Task<Bookmark?> CreateBookmarkAsync(string userId, int configId)
+    {
+        var existing = await _context.Bookmarks
+            .Where(b => b.UserId.Equals(userId) && b.ConfigurationId.Equals(configId))
+            .FirstOrDefaultAsync();
+
+        if (existing != null)
+        {
+            return null;
+        }
+
+        var bookmark = new Bookmark()
+        {
+            UserId = userId,
+            ConfigurationId = configId,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        _context.Bookmarks.Add(bookmark);
+        await _context.SaveChangesAsync();
+
+        // Explicit loading
+        await _context.Entry(bookmark)
+            .Reference(b => b.HardwareConfiguration)
+            .LoadAsync();
+        await _context.Entry(bookmark.HardwareConfiguration)
+            .Reference(c => c.Offer)
+            .LoadAsync();
+
+        return bookmark;
+    }
+
+    /// <summary>
+    /// Deletes a bookmark that references the authenticated user's ID
+    /// and the specified hardware configuration identifier of an offer.
+    /// </summary>
+    public async Task DeleteBookmarkAsync(string userId, int configId)
+    {
+        var existing = await _context.Bookmarks
+            .Where(b => b.UserId.Equals(userId) && b.ConfigurationId.Equals(configId))
+            .FirstOrDefaultAsync();
+
+        if (existing == null)
+        {
+            return;
+        }
+
+        _context.Bookmarks.Remove(existing);
+        await _context.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
Add controller and service methods to retrieve, create, and update bookmarks based on the current authenticated user and the specified `HardwareConfiguration` (i.e., "item") of an offer. 

This may be preferred to these actions being based on the bookmark identifier itself, because the expectation is that bookmarks will be both added and removed from the detailed offer view, where the offer item identifier can be easily accessed.

Because all requests include a token for the JWT-based authentication, it makes sense to use the ASP.NET controller `User` interface to extract the user ID from claims.