### PR TITLE
refactor: use offer request dto

### DIFF
--- a/Server.Tests/OfferService_Test.cs
+++ b/Server.Tests/OfferService_Test.cs
@@ -1,5 +1,5 @@
-﻿using Model;
-using Server.Services;
+﻿using Server.Services;
+using Server.Dtos;
 
 namespace Server.Tests
 {
@@ -22,8 +22,8 @@ namespace Server.Tests
             var service = new OfferService(_fixture.Context);
 
             // Act
-            HardwareConfiguration item_existing = await service.GetOfferConfigurationAsync(1);
-            HardwareConfiguration item_notExisting = await service.GetOfferConfigurationAsync(32767);
+            OfferItemDto item_existing = await service.GetOfferConfigurationAsync(1);
+            OfferItemDto item_notExisting = await service.GetOfferConfigurationAsync(32767);
 
             // Assert
             Assert.NotNull(item_existing);
@@ -42,10 +42,10 @@ namespace Server.Tests
             var service = new OfferService(_fixture.Context);
 
             // Act
-            var result = await service.GetOffersAsync(null, [], []);
+            var result = await service.GetOffersAsync(new GetOffersRequestDto() {});
 
             // Assert
-            Assert.Equal(expected, result.SelectMany(o => o.Configurations).Count());
+            Assert.Equal(expected, result.Count());
         }
 
         /// <summary>
@@ -59,10 +59,13 @@ namespace Server.Tests
             var service = new OfferService(_fixture.Context);
 
             // Act
-            var result = await service.GetOffersAsync("Desktops", [], []);
+            var result = await service.GetOffersAsync(new GetOffersRequestDto()
+            { 
+                Category = "Desktops"
+            });
 
             // Assert
-            Assert.Equal(3, result.SelectMany(o => o.Configurations).Count());
+            Assert.Equal(3, result.Count());
             Assert.All(result, o => Assert.Equal("Desktops", o.Category));
         }
 
@@ -77,11 +80,14 @@ namespace Server.Tests
             var service = new OfferService(_fixture.Context);
 
             // Act
-            var result = await service.GetOffersAsync(null, [16], []);
+            var result = await service.GetOffersAsync(new GetOffersRequestDto()
+            {
+                Memory = [16]
+            });
 
             // Assert
-            Assert.Equal(2, result.SelectMany(o => o.Configurations).Count());
-            Assert.All(result, o => Assert.True(o.Configurations.All(c => c.MemoryCapacity == 16)));
+            Assert.Equal(2, result.Count());
+            Assert.All(result, o => Assert.True(o.MemoryCapacity == 16));
         }
 
         /// <summary>
@@ -95,11 +101,14 @@ namespace Server.Tests
             var service = new OfferService(_fixture.Context);
 
             // Act
-            var result = await service.GetOffersAsync(null, [], [256]);
+            var result = await service.GetOffersAsync(new GetOffersRequestDto()
+            {
+                Storage = [256]
+            });
 
             // Assert
-            Assert.Equal(2, result.SelectMany(o => o.Configurations).Count());
-            Assert.All(result, o => Assert.True(o.Configurations.All(c => c.StorageSize == 256)));
+            Assert.Equal(2, result.Count());
+            Assert.All(result, o => Assert.True(o.StorageSize == 256));
         }
 
         /// <summary>
@@ -114,13 +123,17 @@ namespace Server.Tests
             var storage = new List<short>() { 256, 512 };
 
             // Act
-            var result = await service.GetOffersAsync(null, [16], storage);
+            var result = await service.GetOffersAsync(new GetOffersRequestDto()
+            {
+                Memory = [16],
+                Storage = storage
+            });
 
             // Assert
-            Assert.Equal(2, result.SelectMany(o => o.Configurations).Count());
+            Assert.Equal(2, result.Count());
             Assert.All(result, o => Assert.Equal("Desktops", o.Category));
-            Assert.All(result, o => Assert.True(o.Configurations.All(c => c.MemoryCapacity == 16)));
-            Assert.All(result, o => Assert.True(o.Configurations.All(c => c.StorageSize == 256 || c.StorageSize == 512)));
+            Assert.All(result, o => Assert.True(o.MemoryCapacity == 16));
+            Assert.All(result, o => Assert.True(o.StorageSize == 256 || o.StorageSize == 512));
         }
 
         /// <summary>
@@ -134,12 +147,17 @@ namespace Server.Tests
             var service = new OfferService(_fixture.Context);
 
             // Act
-            var result = await service.GetOffersAsync("Desktops", [16], [256]);
+            var result = await service.GetOffersAsync(new GetOffersRequestDto()
+            {
+                Category = "Desktops",
+                Memory = [16],
+                Storage = [256]
+            });
 
             // Assert
             Assert.All(result, o => Assert.Equal("Desktops", o.Category));
-            Assert.All(result, o => Assert.True(o.Configurations.All(c => c.MemoryCapacity == 16)));
-            Assert.All(result, o => Assert.True(o.Configurations.All(c => c.StorageSize == 256)));
+            Assert.All(result, o => Assert.True(o.MemoryCapacity == 16));
+            Assert.All(result, o => Assert.True(o.StorageSize == 256));
         }
     }
 }

--- a/Server/Controllers/OffersController.cs
+++ b/Server/Controllers/OffersController.cs
@@ -21,34 +21,9 @@ namespace Server.Controllers
         /// <returns></returns>
         [HttpGet] // GET: api/Offers
         public async Task<ActionResult<ICollection<OfferItemDto>>> GetOffers(
-            [FromQuery] string? category,
-            [FromQuery] List<short> memory,
-            [FromQuery] List<short> storage)
+            [FromQuery] GetOffersRequestDto request)
         {
-            List <OfferItemDto> items = [];
-            IEnumerable<Model.Offer> offers = await _service
-                .GetOffersAsync(category, memory, storage);
-
-            foreach (var offer in offers)
-            {
-                foreach (var config in offer.Configurations)
-                {
-                    items.Add(new OfferItemDto
-                    {
-                        Id = config.Id,
-                        Category = offer.Category,
-                        Title = offer.Title,
-                        Photo = offer.Photo,
-                        MemoryCapacity = config.MemoryCapacity,
-                        StorageSize = config.StorageSize,
-                        Price = config.Price,
-                        IsSoldOut = offer.IsSoldOut,
-                        Url = offer.Url,
-                    });
-                }
-            }
-
-            return items;
+            return Ok(await _service.GetOffersAsync(request));
         }
 
         /// <summary>
@@ -65,19 +40,10 @@ namespace Server.Controllers
             {
                 return NotFound();
             }
-
-            return new OfferItemDto
+            else
             {
-                Id = item.Id,
-                Category = item.Offer.Category,
-                Title = item.Offer.Title,
-                Photo = item.Offer.Photo,
-                MemoryCapacity = item.MemoryCapacity,
-                StorageSize = item.StorageSize,
-                Price = item.Price,
-                IsSoldOut = item.Offer.IsSoldOut,
-                Url = item.Offer.Url,
-            };
+                return Ok(item);
+            }
         }
     }
 }

--- a/Server/Dtos/GetOffersRequestDto.cs
+++ b/Server/Dtos/GetOffersRequestDto.cs
@@ -1,0 +1,21 @@
+﻿namespace Server.Dtos;
+
+public class GetOffersRequestDto
+{
+    /// <summary>
+    /// Computer category (e.g., "desktop")
+    /// </summary>
+    public string? Category { get; set; }
+
+    /// <summary>
+    /// System RAM in GB.
+    /// </summary>
+    public List<short>? Memory { get; set; }
+
+    /// <summary>
+    /// System storage in GB.
+    /// </summary>
+    public List<short>? Storage { get; set; }
+
+    public string? SortOrder { get; set; }
+}

--- a/Server/Services/OfferService.cs
+++ b/Server/Services/OfferService.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Model;
+using Server.Dtos;
 
 namespace Server.Services;
 
@@ -15,43 +16,69 @@ public class OfferService
 
     /// <summary>
     /// Gets all offer hardware configurations from the database;
-    /// optionally, filter by offer category and/or config memory/storage.
+    /// optionally, filter by offer category and/or config memory/storage
+    /// and sort by
     /// </summary>
-    /// <param name="category">Computer category (e.g., "desktop").</param>
-    /// <param name="memory">System RAM in GB.</param>
-    /// <param name="storage">System storage in GB.</param>
-    public async Task<IEnumerable<Offer>> GetOffersAsync(
-        string? category,
-        List<short> memory,
-        List<short> storage)
+    public async Task<IEnumerable<OfferItemDto>> GetOffersAsync(GetOffersRequestDto request)
     {
-        var filteredOffers = await _context.Offers
-                .Where(o => !o.IsSoldOut)
-                .Where(o => category.IsNullOrEmpty() || o.Category.Equals(category))
-                .Include(o => o.Configurations)
-                .Where(o => o.Configurations
-                    .Any(c => (memory.IsNullOrEmpty() || memory.Contains(c.MemoryCapacity))
-                    && (storage.IsNullOrEmpty() || storage.Contains(c.StorageSize))
-                    && (c.MemoryCapacity != 0 && c.StorageSize != 0)))
-                .Select (o => new Offer
-                {
-                    Id = o.Id,
-                    WootId = o.WootId,
-                    Category = o.Category,
-                    Title = o.Title,
-                    Photo = o.Photo,
-                    IsSoldOut = o.IsSoldOut,
-                    Condition = o.Condition,
-                    Url = o.Url,
-                    // AND across filter types; OR within filter types.
-                    Configurations = (ICollection<HardwareConfiguration>) o.Configurations
-                        .Where(c => ((memory.IsNullOrEmpty() || memory.Contains(c.MemoryCapacity))
-                        && (storage.IsNullOrEmpty() || storage.Contains(c.StorageSize))
-                        && (c.MemoryCapacity != 0 && c.StorageSize != 0))) // Malformed offers.
-                })
-                .ToListAsync();
+        var offers = await _context.Offers
+            .Where(o => !o.IsSoldOut)
+            .Where(o => request.Category.IsNullOrEmpty()
+                || o.Category.Equals(request.Category))
+            .Include(o => o.Configurations)
+            .Where(o => o.Configurations
+                .Any(c => (request.Memory.IsNullOrEmpty()
+                    || request.Memory.Contains(c.MemoryCapacity))
+                && (request.Storage.IsNullOrEmpty()
+                    || request.Storage.Contains(c.StorageSize))
+                && (c.MemoryCapacity != 0 && c.StorageSize != 0)))
+            .Select (o => new Offer
+            {
+                Id = o.Id,
+                WootId = o.WootId,
+                Category = o.Category,
+                Title = o.Title,
+                Photo = o.Photo,
+                IsSoldOut = o.IsSoldOut,
+                Condition = o.Condition,
+                Url = o.Url,
+                // AND across filter types; OR within filter types.
+                Configurations = (ICollection<HardwareConfiguration>) o.Configurations
+                    .Where(c => ((request.Memory.IsNullOrEmpty()
+                        || request.Memory.Contains(c.MemoryCapacity))
+                    && (request.Storage.IsNullOrEmpty()
+                        || request.Storage.Contains(c.StorageSize))
+                    && (c.MemoryCapacity != 0 && c.StorageSize != 0))) // Malformed offers.
+            })
+            .ToListAsync();
 
-        return filteredOffers;
+        List<OfferItemDto> items = [];
+
+        // Convert to OfferItemDtos, separating out the configurations.
+        foreach (var offer in offers)
+        {
+            foreach (var config in offer.Configurations)
+            {
+                items.Add(new OfferItemDto
+                {
+                    Id = config.Id,
+                    Category = offer.Category,
+                    Title = offer.Title,
+                    Photo = offer.Photo,
+                    MemoryCapacity = config.MemoryCapacity,
+                    StorageSize = config.StorageSize,
+                    Price = config.Price,
+                    IsSoldOut = offer.IsSoldOut,
+                    Url = offer.Url,
+                });
+            }
+        }
+
+        items = (request.SortOrder != "desc")
+        ? items.OrderBy(i => i.Price).ToList()
+        : items.OrderByDescending(i => i.Price).ToList();
+
+        return items;
     }
 
     /// <summary>
@@ -59,11 +86,31 @@ public class OfferService
     /// </summary>
     /// <param name="id">The hardware configuration ID.</param>
     /// <returns>A hardware configuration (i.e., "item") of an offer.</returns>
-    public async Task<HardwareConfiguration?> GetOfferConfigurationAsync(int id)
+    public async Task<OfferItemDto?> GetOfferConfigurationAsync(int id)
     {
-        return await _context.Configurations
+        var item = await _context.Configurations
             .Where(c => c.Id.Equals(id))
             .Include (c => c.Offer)
             .FirstOrDefaultAsync();
+
+        if (item == null)
+        {
+            return null;
+        }
+        else
+        {
+            return new OfferItemDto()
+            {
+                Id = item.Id,
+                Category = item.Offer.Category,
+                Title = item.Offer.Title,
+                Photo = item.Offer.Photo,
+                MemoryCapacity = item.MemoryCapacity,
+                StorageSize = item.StorageSize,
+                Price = item.Price,
+                IsSoldOut = item.Offer.IsSoldOut,
+                Url = item.Offer.Url,
+            };
+        }
     }
 }


### PR DESCRIPTION
To take advantage of TypeScript's strongly-typed nature and better define the client-server contract, introduce a `GetOffersRequestDto` that is mirrored by an interface in the Angular SPA.

Additionally, refactor `OfferService` to return `OfferItemDto` instead of building it from offer(s) inside `OffersController`. This allows offer-item sorting to be performed within a service instead of the controller, allowing it to handle its own narrow set of responsibilities.